### PR TITLE
Update API for 0.8 version of browser extension

### DIFF
--- a/app/assets/images/link_icon.svg
+++ b/app/assets/images/link_icon.svg
@@ -1,0 +1,3 @@
+<svg fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M13.19 8.688a4.5 4.5 0 011.242 7.244l-4.5 4.5a4.5 4.5 0 01-6.364-6.364l1.757-1.757m13.35-.622l1.757-1.757a4.5 4.5 0 00-6.364-6.364l-4.5 4.5a4.5 4.5 0 001.242 7.244"></path>
+</svg>

--- a/app/controllers/admin/ratings_controller.rb
+++ b/app/controllers/admin/ratings_controller.rb
@@ -1,0 +1,74 @@
+class Admin::RatingsController < Admin::BaseController
+  include TranzitoUtils::SortableTable
+  before_action :set_period, only: [:index]
+  before_action :find_rating, except: [:index]
+
+  def index
+    page = params[:page] || 1
+    @per_page = params[:per_page] || 50
+    @ratings = searched_ratings.reorder("ratings.#{sort_column} #{sort_direction}")
+      .includes(:citation, :topics).page(page).per(@per_page)
+  end
+
+  def show
+  end
+
+  private
+
+  def sortable_columns
+    %w[created_at user_id display_name]
+  end
+
+  def searched_ratings
+    ratings = Rating
+    if current_topics.present?
+      ratings = ratings.matching_topics(current_topics)
+    end
+
+    ratings = ratings.where(user_id: user_subject.id) if user_subject.present?
+
+    ratings = ratings.display_name_search(params[:query]) if params[:query].present?
+
+    if TranzitoUtils::Normalize.boolean(params[:search_disagree])
+      @search_agreement = "disagree"
+      ratings = ratings.disagree
+    elsif TranzitoUtils::Normalize.boolean(params[:search_agree])
+      @search_agreement = "agree"
+      ratings = ratings.agree
+    end
+
+    if TranzitoUtils::Normalize.boolean(params[:search_quality_low])
+      @search_quality = "low"
+      ratings = ratings.quality_low
+    elsif TranzitoUtils::Normalize.boolean(params[:search_quality_high])
+      @search_quality = "high"
+      ratings = ratings.quality_high
+    end
+
+    if TranzitoUtils::Normalize.boolean(params[:search_learned_something])
+      @search_learned_something = true
+      ratings = ratings.learned_something
+    end
+    if TranzitoUtils::Normalize.boolean(params[:search_changed_opinion])
+      @search_changed_opinion = true
+      ratings = ratings.changed_opinion
+    end
+
+    if TranzitoUtils::Normalize.boolean(params[:search_significant_factual_error])
+      @search_significant_factual_error = true
+      ratings = ratings.significant_factual_error
+    end
+
+    if TranzitoUtils::Normalize.boolean(params[:search_not_understood])
+      @search_not_understood = true
+      ratings = ratings.not_understood
+    end
+
+    @time_range_column = (sort_column == "updated_at") ? "updated_at" : "created_at"
+    ratings.where(@time_range_column => @time_range)
+  end
+
+  def find_rating
+    @rating = Rating.find_by_id(params[:id])
+  end
+end

--- a/app/controllers/api/v1/auths_controller.rb
+++ b/app/controllers/api/v1/auths_controller.rb
@@ -5,7 +5,7 @@ module API
 
       def status
         if current_user.present?
-          render json: {message: "authenticated"}
+          render json: {message: "authenticated", name: current_user.username}
         end
       end
 
@@ -14,7 +14,7 @@ module API
         password = params.dig(:user, :password) || params[:password]
         user = User.find_by_email(email)
         if user&.valid_password?(password)
-          render json: {review_token: user.api_token}
+          render json: {review_token: user.api_token, name: user.username}
         else
           render(json: {message: "Incorrect email or password"}, status: :unauthorized)
         end

--- a/app/controllers/api/v1/ratings_controller.rb
+++ b/app/controllers/api/v1/ratings_controller.rb
@@ -1,0 +1,28 @@
+# NOTE: This controller is deprecated, it's named incorrectly (should be rating)
+module API
+  module V1
+    class RatingsController < APIV1Controller
+      before_action :ensure_current_user!
+
+      def create
+        pparams = permitted_params
+        rating = Rating.find_or_build_for(pparams.merge(skip_rating_created_event: true))
+        if rating.save
+          RatingCreatedEventJob.new.perform(rating.id, rating)
+          share_msg = ShareFormatter.share_user(current_user.reload, rating.timezone)
+          render json: {message: "Rating added", share: share_msg}
+        else
+          render(json: {message: rating.errors.full_messages}, status: 400)
+        end
+      end
+
+      def permitted_params
+        params.require(:rating)
+          .permit(:agreement, :changed_opinion, :citation_title, :not_understood,
+            :error_quotes, :learned_something, :quality, :significant_factual_error,
+            :source, :submitted_url, :timezone, :topics_text)
+          .merge(user_id: current_user.id)
+      end
+    end
+  end
+end

--- a/app/controllers/landing_controller.rb
+++ b/app/controllers/landing_controller.rb
@@ -12,6 +12,10 @@ class LandingController < ApplicationController
   def browser_extensions
   end
 
+  def browser_extension_auth
+    redirect_to_signup_unless_user_present!
+  end
+
   def support
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -185,8 +185,6 @@ module ApplicationHelper
     c_name.singularize.titleize
   end
 
-  private
-
   def display_icon(str)
     image_tag("#{str}_icon.svg", class: "w-4 inline-block")
   end

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -141,8 +141,14 @@ class Rating < ApplicationRecord
 
   # Added to make testing rating form errors easy
   def not_error_url
-    return true if submitted_url.downcase != "error"
-    errors.add(:submitted_url, "'#{submitted_url}' is not valid")
+    case submitted_url.downcase
+    when "error"
+      errors.add(:submitted_url, "'#{submitted_url}' is not valid")
+    when /\Ahttps:\/\/mail.google.com\/mail/
+      errors.add(:submitted_url, "looks like an email inbox - which can't be shared")
+    else
+      true
+    end
   end
 
   def account_private?

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -165,6 +165,10 @@ class Rating < ApplicationRecord
     end
   end
 
+  def meta_present?
+    citation_metadata.present?
+  end
+
   def associate_citation
     self.citation_title = nil if citation_title.blank?
     self.citation = Citation.find_or_create_for_url(submitted_url, citation_title)

--- a/app/views/admin/citations/_table.html.erb
+++ b/app/views/admin/citations/_table.html.erb
@@ -12,7 +12,7 @@
           </th>
         <% end %>
         <th>
-          <%= sortable "title", skip_sortable: skip_sortable, class: "sortable-link-narrow" %></div>
+          <%= sortable "title", skip_sortable: skip_sortable, class: "sortable-link-narrow" %>
         <% if !skip_sortable %>
           <%= sortable "url", skip_sortable: skip_sortable, class: "sortable-link-narrow" %>
         <% end %>

--- a/app/views/admin/citations/_table.html.erb
+++ b/app/views/admin/citations/_table.html.erb
@@ -13,40 +13,40 @@
         <% end %>
         <th>
           <%= sortable "title", skip_sortable: skip_sortable, class: "sortable-link-narrow" %>
-        <% if !skip_sortable %>
-          <%= sortable "url", skip_sortable: skip_sortable, class: "sortable-link-narrow" %>
-        <% end %>
-      </th>
-      <th>Topics</th>
-      <th>Ratings</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% citations.each do |citation| %>
-      <tr>
-        <td>
-          <% if display_dev_info? %><code class="only-dev-visible-small"><%= citation.id %></code><% end %>
-          <%= link_to l(citation.created_at, format: :convert_time), edit_admin_citation_path(citation), class: "convertTime" %>
-        </td>
-        <% if render_updated_at %>
-          <td>
-            <small class="convertTime"><%= l(citation.updated_at, format: :convert_time) %></small>
-          </td>
-        <% end %>
-        <td>
-          <%= citation.title %>
-          <% if citation.url.present? %>
-            <small class="block">
-              <%= link_to citation.url.truncate(100), citation.url, title: citation.url %>
-            </small>
+          <% if !skip_sortable %>
+            <%= sortable "url", skip_sortable: skip_sortable, class: "sortable-link-narrow" %>
           <% end %>
-        </td>
-        <td>
-          <small><%= citation.topics_string %></small>
-        </td>
-        <td><%= admin_number_display(citation.ratings.count) %></td>
+        </th>
+        <th>Topics</th>
+        <th>Ratings</th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      <% citations.each do |citation| %>
+        <tr>
+          <td>
+            <% if display_dev_info? %><code class="only-dev-visible-small"><%= citation.id %></code><% end %>
+            <%= link_to l(citation.created_at, format: :convert_time), edit_admin_citation_path(citation), class: "convertTime" %>
+          </td>
+          <% if render_updated_at %>
+            <td>
+              <small class="convertTime"><%= l(citation.updated_at, format: :convert_time) %></small>
+            </td>
+          <% end %>
+          <td>
+            <%= citation.title %>
+            <% if citation.url.present? %>
+              <small class="block">
+                <%= link_to citation.url.truncate(100), citation.url, title: citation.url %>
+              </small>
+            <% end %>
+          </td>
+          <td>
+            <small><%= citation.topics_string %></small>
+          </td>
+          <td><%= admin_number_display(citation.ratings.count) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
 </div>

--- a/app/views/admin/ratings/_table.html.erb
+++ b/app/views/admin/ratings/_table.html.erb
@@ -1,0 +1,64 @@
+<% ratings ||= @ratings %>
+<% skip_sortable ||= false %>
+<% filter_links ||= true %>
+
+<% table_classes = "table table-sm break-words max-w-full" %>
+<div class="">
+  <table class="<%= table_classes %>">
+    <thead class="sortable">
+      <tr>
+        <th>
+          <%= sortable "created_at", "Rated", skip_sortable: skip_sortable, class: "sortable-link-narrow" %>
+          <% if !skip_sortable %>
+            <%= sortable "user_id", skip_sortable: skip_sortable, class: "sortable-link-narrow" %>
+          <% end %>
+        </th>
+        <th>
+          <%= sortable "display_name", "Article", skip_sortable: skip_sortable %>
+        </th>
+        <th>Version</th>
+        <th class="break-normal text-center border-r">
+          <span title="Error?">E<span class="hidden md:inline">rror?</span></span>
+        </th>
+        <th>Meta?</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% ratings.each do |rating| %>
+        <tr>
+          <td>
+            <% if display_dev_info? %><code class="only-dev-visible-small ratingId"><%= rating.id %></code><% end %>
+            <small class="convertTime"><%= l(rating.created_at, format: :convert_time) %></small>
+            <small class="inline less-strong">
+              <%= link_to rating.user.username, url_for(sortable_params.merge(user: rating.user.username_slug)) %>
+            </small>
+          </td>
+          <td>
+            <% rating_text = "missing url" if rating.display_name.blank? || rating.display_name == "missing url" %>
+            <% rating_text ||= rating.display_name %>
+            <%= link_to rating_text, admin_rating_path(rating) %>
+            <%= link_to display_icon("link"), rating.citation_url %>
+
+            <span class="ml-2">
+              <%= agreement_display(rating.agreement, link: filter_links) %>
+              <%= quality_display(rating.quality, link: filter_links) %>
+              <%= learned_something_display(rating.learned_something?, link: filter_links) %>
+              <%= changed_opinion_display(rating.changed_opinion?, link: filter_links) %>
+              <%= significant_factual_error_display(rating.significant_factual_error?, link: filter_links) %>
+            </span>
+            <span class="block text-sm less-strong"><%= rating.topic_names.join(", ") %></span>
+          </td>
+          <td>
+            <small><%= rating.source %></small>
+          </td>
+          <td class="table-cell-check">
+            <%= check_mark if rating.significant_factual_error %>
+          </td>
+          <td class="table-cell-check">
+            <%= check_mark if rating.meta_present? %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/admin/ratings/index.html.erb
+++ b/app/views/admin/ratings/index.html.erb
@@ -1,0 +1,24 @@
+<%= content_for :main_wrapper_class, "container-padded" %>
+<div class="large-width-container">
+  <h1 class="standard-top-offset mb-4">Admin Ratings</h1>
+
+  <%= form_tag admin_ratings_path, method: :get do %>
+    <%= render partial: "/shared/hidden_search_fields" %>
+    <div class="row sm:grid-cols-2 mb-4">
+      <div class="col">
+        <div class="form-row">
+          <%= label_tag :query %>
+          <%= text_field_tag :query, params[:query], class: "form-control" %>
+        </div>
+      </div>
+      <div class="col">
+        <div class="form-row-btn sm:mt-8">
+          <%= submit_tag "search", class: "btn" %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
+  <%= render partial: "/shared/current_header", locals: {collection: @ratings, render_period: true} %>
+</div>
+<%= render partial: "/admin/ratings/table", locals: {ratings: @ratings} %>

--- a/app/views/admin/ratings/show.html.erb
+++ b/app/views/admin/ratings/show.html.erb
@@ -1,0 +1,15 @@
+<%= content_for :main_wrapper_class, "container-padded" %>
+<div class="large-width-container mb-5">
+  <h1 class="standard-top-offset mb-4">Admin Rating</h1>
+</div>
+
+<%= render partial: "/admin/ratings/table", locals: {ratings: [@rating], skip_sortable: true} %>
+
+<div class="large-width-container">
+  <h3 class="mt-5">Metadata:</h3>
+  <% if @rating.meta_present? %>
+    <%= pretty_print_json(@rating.citation_metadata) %>
+  <% else %>
+    No metadata
+  <% end %>
+</div>

--- a/app/views/landing/browser_extension_auth.html.erb
+++ b/app/views/landing/browser_extension_auth.html.erb
@@ -1,0 +1,5 @@
+<h1 class="standard-top-offset">Authenticate your browser extension</h1>
+<h2 class="my-4">Congratulations! You've signed in to your browser extension</h2>
+<script>
+  window.apiToken = '<%= current_user.api_token %>';
+</script>

--- a/app/views/landing/browser_extension_auth.html.erb
+++ b/app/views/landing/browser_extension_auth.html.erb
@@ -1,5 +1,6 @@
 <h1 class="standard-top-offset">Authenticate your browser extension</h1>
 <h2 class="my-4">Congratulations! You've signed in to your browser extension</h2>
+<p class="mt-4">You can close this window</p>
 <script>
   window.apiToken = '<%= current_user.api_token %>';
 </script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,9 +30,10 @@
         <% if in_admin? %>
           <%= active_link "Users", admin_users_path, class: "main-nav-link ml-2", match_controller: true %>
           <%= active_link "Topics", admin_topics_path, class: "main-nav-link ml-2", match_controller: true %>
-          <%= active_link "Reviews", admin_topic_reviews_path, class: "main-nav-link ml-2", match_controller: true %>
-          <%= active_link "Citations", admin_citations_path, class: "main-nav-link ml-2", match_controller: true %>
+          <%= active_link "Rev", admin_topic_reviews_path, class: "main-nav-link ml-2", match_controller: true %>
+          <%= active_link "Cit", admin_citations_path, class: "main-nav-link ml-2", match_controller: true %>
           <%= active_link "Pubs", admin_publishers_path, class: "main-nav-link ml-2", match_controller: true %>
+          <%= active_link "Rat", admin_ratings_path, class: "main-nav-link ml-2", match_controller: true %>
           <%= link_to "Exit", user_root_url, class: "main-nav-link ml-auto less-strong" %>
         <% else %>
           <% ratings_active = controller_name == "ratings" && viewing_display_name == "all" %>

--- a/app/views/ratings/_form.html.erb
+++ b/app/views/ratings/_form.html.erb
@@ -1,3 +1,4 @@
+<%# previously, this mirrored the browser extension. As of v0.8, that isn't true anymore %>
 <% rating ||= Rating.new %>
 <% render_menu ||= false %>
 <% editing_rating = rating.id.present? %>
@@ -23,6 +24,7 @@
   </div>
 <% end %>
 <%# Need to manually specify the URL and method here because it can't just be the path %>
+
 <% form_url = editing_rating ? rating_url(rating) : ratings_url %>
 <% collapsible_field_classes = editing_rating ? '' : 'hidden' %>
 <%= form_with(model: rating, url: form_url, method: (editing_rating ? :patch : :post), class: "pb-2") do |f| %>

--- a/app/views/shared/_current_header.html.erb
+++ b/app/views/shared/_current_header.html.erb
@@ -1,6 +1,6 @@
 <%# NOTE: when you add new search_ params here, also add it to hidden_search_fields %>
 <% viewing ||= controller_name.humanize %>
-<% current_header_keys = %w[search_topics] %>
+<% current_header_keys = %w[search_topics user_subject] %>
 <% header_present ||= (current_header_keys & params.keys).any? %>
 <% if header_present %>
   <div>
@@ -11,6 +11,16 @@
         <small class="less-strong">
           <%= viewing %> for
           <%= link_to "all topics", url_for(sortable_params.merge(search_topics: nil)) %>
+        </small>
+      </p>
+    <% end %>
+    <% if user_subject.present? %>
+      <p class="mb-2">
+        <%= viewing %> for
+        <strong><%= user_subject.username %></strong>
+        <small class="less-strong">
+          <%= viewing %> for
+          <%= link_to "all users", url_for(sortable_params.merge(user: nil)) %>
         </small>
       </p>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,7 @@ Rails.application.routes.draw do
     resources :topic_reviews, except: [:show]
     resources :topic_review_citations, only: %i[edit update]
     resources :citations, only: %i[index edit update show]
+    resources :ratings, only: %i[index show]
     resources :publishers, only: %i[index edit update show]
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
   get "/support", to: "landing#support"
   get "/browser_extensions", to: "landing#browser_extensions"
   get "/browser_extension", to: redirect("browser_extensions")
+  get "/browser_extension_auth", to: "landing#browser_extension_auth"
 
   resources :ratings, except: [:show] do
     collection { post :add_topic }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
         collection { get :status }
       end
       resources :reviews, only: [:create]
+      resources :ratings, only: [:create]
       resources :citations, only: %i[index show] do
         collection { post :filepath }
       end

--- a/db/migrate/20230419003617_add_citation_metadata_to_ratings.rb
+++ b/db/migrate/20230419003617_add_citation_metadata_to_ratings.rb
@@ -1,0 +1,5 @@
+class AddCitationMetadataToRatings < ActiveRecord::Migration[7.0]
+  def change
+    add_column :ratings, :citation_metadata, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_11_163918) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_19_003617) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -106,6 +106,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_11_163918) do
     t.boolean "not_understood", default: false
     t.text "display_name"
     t.boolean "account_public", default: false
+    t.jsonb "citation_metadata"
     t.index ["citation_id"], name: "index_ratings_on_citation_id"
     t.index ["user_id"], name: "index_ratings_on_user_id"
   end

--- a/spec/requests/admin/ratings_request_spec.rb
+++ b/spec/requests/admin/ratings_request_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+base_url = "/admin/ratings"
+RSpec.describe base_url, type: :request do
+  let(:rating) { FactoryBot.create(:rating) }
+  describe "index" do
+    it "sets return to" do
+      get base_url
+      expect(response).to redirect_to new_user_session_path
+      expect(session[:user_return_to]).to eq "/admin/ratings"
+    end
+
+    context "signed in" do
+      include_context :logged_in_as_user
+      it "flash errors" do
+        get base_url
+        expect(response).to redirect_to root_url
+        expect(flash[:error]).to be_present
+      end
+    end
+  end
+
+  context "signed in as admin" do
+    include_context :logged_in_as_admin
+    describe "index" do
+      it "renders" do
+        expect(rating).to be_valid
+        get base_url
+        expect(response.code).to eq "200"
+        expect(response).to render_template("admin/ratings/index")
+        expect(assigns(:ratings).pluck(:id)).to eq([rating.id])
+        # test out alphabetical sort
+        get "#{base_url}?sort=name"
+        expect(response.code).to eq "200"
+        expect(response).to render_template("admin/ratings/index")
+        expect(assigns(:ratings).pluck(:id)).to eq([rating.id])
+      end
+    end
+
+    describe "show" do
+      it "renders" do
+        expect(rating).to be_valid
+        get "#{base_url}/#{rating.id}"
+        expect(response.code).to eq "200"
+        expect(response).to render_template("admin/ratings/show")
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/auths_request_spec.rb
+++ b/spec/requests/api/v1/auths_request_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe base_url, type: :request do
         get "#{base_url}/status", params: {api_token: current_user.api_token},
           headers: {"HTTP_ORIGIN" => "*"}
         expect(response.code).to eq "200"
-        expect_hashes_to_match(json_result, {message: "authenticated"})
+        expect_hashes_to_match(json_result, {message: "authenticated", name: current_user.username})
         expect(response.headers["access-control-allow-origin"]).to eq("*")
         expect(response.headers["access-control-allow-methods"]).to eq all_request_methods
       end
@@ -49,7 +49,7 @@ RSpec.describe base_url, type: :request do
           "Authorization" => "Bearer #{current_user.api_token}"
         }
         expect(response.code).to eq "200"
-        expect_hashes_to_match(json_result, {message: "authenticated"})
+        expect_hashes_to_match(json_result, {message: "authenticated", name: current_user.username})
         expect(response.headers["access-control-allow-origin"]).to eq("*")
         expect(response.headers["access-control-allow-methods"]).to eq all_request_methods
       end
@@ -63,6 +63,7 @@ RSpec.describe base_url, type: :request do
       }.to_json
       expect(response.code).to eq "200"
       expect(json_result[:review_token]).to eq current_user.api_token
+      expect(json_result[:name]).to eq current_user.username
     end
 
     context "bare user" do

--- a/spec/requests/landing_request_spec.rb
+++ b/spec/requests/landing_request_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe "/", type: :request do
       expect(response).to redirect_to("/users/sign_in")
     end
     context "current_user present" do
+      include_context :logged_in_as_user
       it "renders" do
         get "/browser_extension_auth"
         expect(response.code).to eq "200"

--- a/spec/requests/landing_request_spec.rb
+++ b/spec/requests/landing_request_spec.rb
@@ -43,6 +43,20 @@ RSpec.describe "/", type: :request do
     end
   end
 
+  describe "/browser_extension_auth" do
+    it "redirects" do
+      get "/browser_extension_auth"
+      expect(response).to redirect_to("/users/sign_in")
+    end
+    context "current_user present" do
+      it "renders" do
+        get "/browser_extension_auth"
+        expect(response.code).to eq "200"
+        expect(response).to render_template("landing/browser_extension_auth")
+      end
+    end
+  end
+
   describe "/privacy" do
     it "renders" do
       get "/privacy"


### PR DESCRIPTION
- Add `api/v1/ratings` (replacing deprecated named named `/reviews`
- Add a browser extension page for authentication
- Add meta attributes to ratings