### PR TITLE
Update rating citation_metadata

### DIFF
--- a/app/jobs/update_citation_metadata_from_ratings_job.rb
+++ b/app/jobs/update_citation_metadata_from_ratings_job.rb
@@ -27,7 +27,6 @@ class UpdateCitationMetadataFromRatingsJob < ApplicationJob
     citation
   end
 
-  # TODO: Order by version, then submission
   def ordered_ratings(citation)
     citation.ratings.metadata_present.order(version_integer: :desc, metadata_at: :desc)
   end

--- a/app/jobs/update_citation_metadata_from_ratings_job.rb
+++ b/app/jobs/update_citation_metadata_from_ratings_job.rb
@@ -9,8 +9,8 @@ class UpdateCitationMetadataFromRatingsJob < ApplicationJob
     new_attributes = (MetadataAttributer::ATTR_KEYS - [:keywords]).map do |attrib|
       next if skipped_attributes.include?(attrib)
 
-      # returns first value that matches, only processing the first that's required
-      val = metadata_attributes.lazy.filter_map { |cma| cma[attrib] }.first
+      # returns first value that matches, only loading the first that matches
+      val = metadata_attributes.lazy.filter_map { |cma| cma[attrib].presence }.first
       val.present? ? [attrib, val] : nil
     end.compact.to_h
 

--- a/app/jobs/update_citation_metadata_from_ratings_job.rb
+++ b/app/jobs/update_citation_metadata_from_ratings_job.rb
@@ -3,23 +3,21 @@ class UpdateCitationMetadataFromRatingsJob < ApplicationJob
 
   def perform(id)
     citation = Citation.find(id)
-    citation_metadata_attributes = ordered_ratings(citation)
-      .map(&:citation_metadata_attributes)
+    metadata_attributes = ordered_ratings(citation).map(&:metadata_attributes)
 
     skipped_attributes = citation.manually_updated_attributes.map(&:to_sym)
-
     new_attributes = (MetadataAttributer::ATTR_KEYS - [:keywords]).map do |attrib|
       next if skipped_attributes.include?(attrib)
 
-      # returns first value that matches, only process the first that's required
-      val = citation_metadata_attributes.lazy.filter_map { |cma| cma[attrib] }.first
+      # returns first value that matches, only processing the first that's required
+      val = metadata_attributes.lazy.filter_map { |cma| cma[attrib] }.first
       val.present? ? [attrib, val] : nil
     end.compact.to_h
 
     if new_attributes[:published_updated_at].present? && new_attributes[:published_at].present?
       new_attributes[:published_updated_at] = nil if new_attributes[:published_updated_at] <= new_attributes[:published_at]
     end
-    citation.update(new_attributes.except(:publisher_name, :topic_names))
+    citation.update(new_attributes.except(:publisher_name))
 
     if new_attributes[:publisher_name].present? && !citation.publisher.name_assigned?
       citation.publisher.update(name: new_attributes[:publisher_name])
@@ -28,6 +26,9 @@ class UpdateCitationMetadataFromRatingsJob < ApplicationJob
   end
 
   def ordered_ratings(citation)
-    citation.ratings.metadata_present.order(version_integer: :desc, metadata_at: :desc)
+    # Process any unprocessed ratings. This is where processing happens normally
+    citation.ratings.metadata_unprocessed.each { |c| c.set_metadata_attributes! }
+    # Then, return in order
+    citation.reload.ratings.metadata_present.order(version_integer: :desc, metadata_at: :desc)
   end
 end

--- a/app/models/citation.rb
+++ b/app/models/citation.rb
@@ -1,5 +1,5 @@
 class Citation < ApplicationRecord
-  COUNTED_META_ATTRS = (MetadataAttributer::ATTR_KEYS - %i[canonical_url published_updated_at paywall publisher_name]).map(&:to_s).freeze
+  COUNTED_META_ATTRS = MetadataAttributer::COUNTED_ATTR_KEYS.map(&:to_s).freeze
 
   belongs_to :publisher
 

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -49,8 +49,8 @@ class Rating < ApplicationRecord
   scope :account_private, -> { where(account_public: false) }
   scope :metadata_present, -> { where("length(citation_metadata::text) > 2") }
   scope :metadata_blank, -> { where("length(citation_metadata::text) <= 2").or(where(citation_metadata: nil)) }
-  scope :metadata_processed, -> { where("citation_metadata ->> 'attrs' IS NOT NULL") }
-  scope :metadata_unprocessed, -> { metadata_present.where("citation_metadata ->> 'attrs' IS NULL") }
+  scope :metadata_processed, -> { where("citation_metadata ->> '#{ATTRS_KEY}' IS NOT NULL") }
+  scope :metadata_unprocessed, -> { metadata_present.where("citation_metadata ->> '#{ATTRS_KEY}' IS NULL") }
 
   attr_accessor :skip_rating_created_event, :skip_topics_job
 

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -1,6 +1,9 @@
 class Rating < ApplicationRecord
   include CreatedDateable
 
+  RAW_KEY = "raw".freeze
+  ATTRS_KEY = "attrs".freeze
+
   AGREEMENT_ENUM = {
     neutral: 0,
     disagree: 1,
@@ -46,6 +49,8 @@ class Rating < ApplicationRecord
   scope :account_private, -> { where(account_public: false) }
   scope :metadata_present, -> { where("length(citation_metadata::text) > 2") }
   scope :metadata_blank, -> { where("length(citation_metadata::text) <= 2").or(where(citation_metadata: nil)) }
+  scope :metadata_processed, -> { where("citation_metadata ->> 'attrs' IS NOT NULL") }
+  scope :metadata_unprocessed, -> { metadata_present.where("citation_metadata ->> 'attrs' IS NULL") }
 
   attr_accessor :skip_rating_created_event, :skip_topics_job
 
@@ -131,7 +136,8 @@ class Rating < ApplicationRecord
   end
 
   def citation_metadata_str=(val)
-    self.citation_metadata = MetadataParser.parse_string(val)
+    m_values = MetadataParser.parse_string(val)
+    self.citation_metadata = m_values.any? ? {RAW_KEY => m_values} : {}
     self.metadata_at = Time.current if citation_metadata.present?
     citation_metadata
   end
@@ -184,6 +190,32 @@ class Rating < ApplicationRecord
     citation_metadata.present?
   end
 
+  def metadata_blank?
+    !metadata_present?
+  end
+
+  def metadata_processed?
+    citation_metadata&.key?(ATTRS_KEY)
+  end
+
+  def metadata_unprocessed?
+    metadata_present? && !metadata_processed?
+  end
+
+  def citation_metadata_raw
+    citation_metadata&.dig(RAW_KEY) || []
+  end
+
+  def metadata_attributes
+    (citation_metadata&.dig(ATTRS_KEY) || {}).symbolize_keys
+  end
+
+  # This is called first in UpdateCitationMetadataFromRatingsJob
+  def set_metadata_attributes!
+    new_attrs = MetadataAttributer.from_rating(self)
+    self.update_column :citation_metadata, citation_metadata.merge(ATTRS_KEY => new_attrs)
+  end
+
   def missing_url?
     display_name.blank? || display_name == "missing url"
   end
@@ -200,7 +232,7 @@ class Rating < ApplicationRecord
     self.topics_text = nil if topics_text.blank?
     self.error_quotes = nil if error_quotes.blank?
     self.account_public = calculated_account_public?
-    self.citation_metadata = [] if citation_metadata.blank?
+    self.citation_metadata = {} if citation_metadata_raw.blank?
     self.metadata_at = nil if citation_metadata.blank?
     self.version_integer = calculated_version_integer
   end
@@ -219,10 +251,6 @@ class Rating < ApplicationRecord
   def calculated_display_name
     citation&.title.presence || citation_title.presence ||
       citation&.display_name || "missing url"
-  end
-
-  def citation_metadata_attributes
-    MetadataAttributer.from_rating(self)
   end
 
   private

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -213,7 +213,7 @@ class Rating < ApplicationRecord
   # This is called first in UpdateCitationMetadataFromRatingsJob
   def set_metadata_attributes!
     new_attrs = MetadataAttributer.from_rating(self)
-    self.update_column :citation_metadata, citation_metadata.merge(ATTRS_KEY => new_attrs)
+    update_column :citation_metadata, citation_metadata.merge(ATTRS_KEY => new_attrs)
   end
 
   def missing_url?

--- a/app/services/metadata_attributer.rb
+++ b/app/services/metadata_attributer.rb
@@ -10,7 +10,7 @@ class MetadataAttributer
 
   class << self
     def from_rating(rating)
-      rating_metadata = rating.citation_metadata
+      rating_metadata = rating.citation_metadata_raw
       return {} if rating_metadata.blank?
       json_ld = json_ld_hash(rating_metadata)
 
@@ -41,7 +41,7 @@ class MetadataAttributer
       else
         # Run through every topic to find matches in the str
         # Issues with this:
-        # - rating.citation_metadata_attributes < calling that becomes (potentially) a big operation
+        # - rating.metadata_attributes < calling that becomes (potentially) a big operation
         # - every time that a topic is added, all the metadata topics need to be recalculated
         # - I want to be able to "see the work" from this and from other things (which is why I added the keywords key)
         #   but... this becomes slow

--- a/app/views/admin/citations/edit.html.erb
+++ b/app/views/admin/citations/edit.html.erb
@@ -107,7 +107,7 @@
 
         <div class="code-small">
           <%# skipping canonical_url for now, because it's just noise %>
-          <%= pretty_print_json(rating.citation_metadata_attributes.except(:canonical_url)) %>
+          <%= pretty_print_json(rating.metadata_attributes.except(:canonical_url)) %>
         </div>
       </div>
     <% end %>

--- a/app/views/admin/ratings/_table.html.erb
+++ b/app/views/admin/ratings/_table.html.erb
@@ -66,7 +66,7 @@
             <%= check_mark if rating.metadata_present? %>
           </td>
           <td class="table-cell-check">
-            <%= check_mark if rating.citation_metadata_attributes[:keywords]&.any? %>
+            <%= check_mark if rating.metadata_attributes[:keywords]&.any? %>
           </td>
         </tr>
       <% end %>

--- a/app/views/admin/ratings/_table.html.erb
+++ b/app/views/admin/ratings/_table.html.erb
@@ -59,14 +59,17 @@
           <% if display_dev_info? %>
             <td>
               <small><%= rating.version_integer %></small>
-
             </td>
           <% end %>
           <td class="table-cell-check">
             <%= check_mark if rating.metadata_present? %>
           </td>
           <td class="table-cell-check">
-            <%= check_mark if rating.metadata_attributes[:keywords]&.any? %>
+            <% if rating.metadata_attributes[:keywords]&.any? %>
+              <%= check_mark %>
+            <% elsif rating.metadata_unprocessed? %>
+              <small class="text-error">unprocessed</small>
+            <% end %>
           </td>
         </tr>
       <% end %>

--- a/app/views/admin/ratings/show.html.erb
+++ b/app/views/admin/ratings/show.html.erb
@@ -101,9 +101,9 @@
 </div>
 
 <div class="large-width-container">
-  <h3 class="mt-5">Full Metadata:</h3>
+  <h3 class="mt-5">Raw Metadata:</h3>
   <% if @rating.metadata_present? %>
-    <div class="code-small"><%= pretty_print_json(@rating.citation_metadata) %></div>
+    <div class="code-small"><%= pretty_print_json(@rating.citation_metadata_raw) %></div>
   <% else %>
     No metadata
   <% end %>

--- a/app/views/admin/ratings/show.html.erb
+++ b/app/views/admin/ratings/show.html.erb
@@ -67,7 +67,7 @@
         </tbody>
       </table>
     </div>
-    <% metadata_attributes = @rating.citation_metadata_attributes %>
+    <% metadata_attributes = @rating.metadata_attributes %>
     <div class="col">
       <h3>Citation metadata attributes:</h3>
       <div class="code-small">

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -228,7 +228,7 @@ RSpec.describe Rating, type: :model do
         expect(rating.reload.metadata_present?).to be_truthy
         expect(rating.metadata_processed?).to be_falsey
         expect(rating.metadata_unprocessed?).to be_truthy
-        expect(rating.citation_metadata_raw).to eq([{"name" => "author","content" => "Cool"}])
+        expect(rating.citation_metadata_raw).to eq([{"name" => "author", "content" => "Cool"}])
         expect(rating.metadata_attributes).to eq({})
         expect(Rating.metadata_processed.pluck(:id)).to eq([])
         expect(Rating.metadata_unprocessed.pluck(:id)).to eq([rating.id])

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -20,8 +20,10 @@ RSpec.describe Rating, type: :model do
         it "has the topics" do
           expect(rating.reload.topic_names).to eq(["something", "other", "things"])
           expect(rating.topics.count).to eq 3
-          expect(rating.citation_metadata).to eq([])
+          expect(rating.citation_metadata).to eq({})
           expect(rating.metadata_present?).to be_falsey
+          expect(rating.metadata_processed?).to be_falsey
+          expect(rating.metadata_unprocessed?).to be_falsey
           expect(Rating.metadata_present.pluck(:id)).to eq([])
         end
       end
@@ -191,14 +193,16 @@ RSpec.describe Rating, type: :model do
     it "assigns metadata_at" do
       expect(rating.metadata_present?).to be_falsey
       rating.citation_metadata_str = '[{"something": "aaaa"}]'
-      expect(rating.citation_metadata).to eq([{"something" => "aaaa"}])
+      expect(rating.citation_metadata).to eq({"raw" => [{"something" => "aaaa"}]})
       expect(rating.metadata_at).to be_within(1).of Time.current
       expect(rating.metadata_present?).to be_truthy
+      expect(rating.metadata_processed?).to be_falsey
+      expect(rating.metadata_unprocessed?).to be_truthy
     end
     context "empty hash" do
       let(:rating) { FactoryBot.create(:rating, citation_metadata_str: "{}") }
       it "assigns to []" do
-        expect(rating.reload.citation_metadata).to eq([])
+        expect(rating.reload.citation_metadata).to eq({})
         expect(rating.metadata_present?).to be_falsey
         expect(Rating.metadata_present.pluck(:id)).to eq([])
       end
@@ -206,13 +210,34 @@ RSpec.describe Rating, type: :model do
     context "create" do
       let(:rating) { FactoryBot.create(:rating, citation_metadata_str: '[{"ff": "zzz"}]') }
       it "assigns metadata_at, blanks if blanked" do
-        expect(rating.reload.citation_metadata).to eq([{"ff" => "zzz"}])
+        expect(rating.reload.citation_metadata).to eq({"raw" => [{"ff" => "zzz"}]})
         expect(rating.metadata_at).to be_within(1).of Time.current
         expect(Rating.metadata_present.pluck(:id)).to eq([rating.id])
         rating.update(citation_metadata_str: "null")
-        expect(rating.reload.citation_metadata).to eq([])
+        expect(rating.reload.citation_metadata).to eq({})
         expect(rating.metadata_at).to be_blank
         expect(Rating.metadata_present.pluck(:id)).to eq([])
+      end
+    end
+  end
+
+  describe "set_metadata_attributes!" do
+    context "author present" do
+      let(:rating) { FactoryBot.create(:rating, citation_metadata_str: '[{"name":"author","content":"Cool"}]') }
+      it "assigns" do
+        expect(rating.reload.metadata_present?).to be_truthy
+        expect(rating.metadata_processed?).to be_falsey
+        expect(rating.metadata_unprocessed?).to be_truthy
+        expect(rating.citation_metadata_raw).to eq([{"name" => "author","content" => "Cool"}])
+        expect(rating.metadata_attributes).to eq({})
+        expect(Rating.metadata_processed.pluck(:id)).to eq([])
+        expect(Rating.metadata_unprocessed.pluck(:id)).to eq([rating.id])
+        rating.set_metadata_attributes!
+        expect(rating.reload.metadata_processed?).to be_truthy
+        expect(rating.metadata_unprocessed?).to be_falsey
+        expect(rating.metadata_attributes.reject { |_k, v| v.blank? }).to eq({authors: ["Cool"]})
+        expect(Rating.metadata_processed.pluck(:id)).to eq([rating.id])
+        expect(Rating.metadata_unprocessed.pluck(:id)).to eq([])
       end
     end
   end

--- a/spec/requests/api/v1/ratings_request_spec.rb
+++ b/spec/requests/api/v1/ratings_request_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe base_url, type: :request do
       )
       rating = Rating.last
       expect_rating_matching_params(json_result, target_response, rating)
-      expect(rating.citation_metadata).to eq([])
+      expect(rating.citation_metadata).to eq({})
     end
     context "rating unwrapped" do
       include_context :test_csrf_token
@@ -69,7 +69,7 @@ RSpec.describe base_url, type: :request do
 
         rating = Rating.last
         expect_rating_matching_params(json_result, target_response, rating)
-        expect(rating.citation_metadata).to eq([])
+        expect(rating.citation_metadata).to eq({})
       end
       context "metadata" do
         let(:citation_metadata) do
@@ -87,15 +87,15 @@ RSpec.describe base_url, type: :request do
 
           rating = Rating.last
           expect_rating_matching_params(json_result, target_response, rating)
-          expect(rating.citation_metadata).to eq citation_metadata.as_json
+          expect(rating.citation_metadata_raw).to eq citation_metadata.as_json
         end
         context "updating" do
-          let!(:rating) { Rating.create(user: current_user, citation_metadata: [{something: "ccc"}], submitted_url: ratings_with_citation_metadata[:submitted_url]) }
+          let!(:rating) { Rating.create(user: current_user, citation_metadata_str: '[{"something": "ccc"}]', submitted_url: ratings_with_citation_metadata[:submitted_url]) }
           let(:ratings_update_params) { ratings_with_citation_metadata.merge(timezone: "America/Los_Angeles") }
           it "updates" do
             expect(rating).to be_valid
             expect(Rating.count).to eq 1
-            expect(rating.reload.citation_metadata).to eq([{"something" => "ccc"}])
+            expect(rating.reload.citation_metadata_raw).to eq([{"something" => "ccc"}])
             expect(rating.created_at.to_date).to eq Time.current.to_date
             post base_url, params: ratings_update_params.to_json,
               headers: json_headers.merge(
@@ -109,7 +109,7 @@ RSpec.describe base_url, type: :request do
             expect(current_user.kudos_events.count).to eq 1
             expect(current_user.kudos_events.created_today.count).to eq 1
             expect_rating_matching_params(json_result, target_response, rating)
-            expect(rating.citation_metadata).to eq citation_metadata.as_json
+            expect(rating.citation_metadata_raw).to eq citation_metadata.as_json
           end
         end
       end

--- a/spec/services/metadata_attributer_spec.rb
+++ b/spec/services/metadata_attributer_spec.rb
@@ -35,9 +35,9 @@ RSpec.describe MetadataAttributer do
         }
       end
       it "returns target" do
-        json_ld = subject.send(:json_ld_hash, rating.citation_metadata)
+        json_ld = subject.send(:json_ld_hash, rating.citation_metadata_raw)
 
-        expect_matching_attributes(rating.citation_metadata, json_ld, metadata_attrs)
+        expect_matching_attributes(rating.citation_metadata_raw, json_ld, metadata_attrs)
       end
       context "with topics" do
         let!(:topic1) { Topic.find_or_create_for_name("Joe Biden") }
@@ -47,11 +47,11 @@ RSpec.describe MetadataAttributer do
         it "returns target" do
           topic1.update(parents_string: "U.S. presidents")
           expect(topic3.reload.children.pluck(:id)).to eq([topic1.id])
-          json_ld = subject.send(:json_ld_hash, rating.citation_metadata)
+          json_ld = subject.send(:json_ld_hash, rating.citation_metadata_raw)
 
           expect(subject.send(:keyword_or_text_topic_names, metadata_attrs)).to eq(topic_names)
 
-          expect_matching_attributes(rating.citation_metadata, json_ld, metadata_attrs.merge(topics_string: topic_names.join(",")))
+          expect_matching_attributes(rating.citation_metadata_raw, json_ld, metadata_attrs.merge(topics_string: topic_names.join(",")))
         end
       end
     end
@@ -74,11 +74,11 @@ RSpec.describe MetadataAttributer do
         }
       end
       it "returns target" do
-        json_ld = subject.send(:json_ld_hash, rating.citation_metadata)
+        json_ld = subject.send(:json_ld_hash, rating.citation_metadata_raw)
 
         expect(subject.send(:json_ld_graph, json_ld, "WebPage", "datePublished")).to eq "2022-02-02T22:43:27+00:00"
 
-        expect_matching_attributes(rating.citation_metadata, json_ld, metadata_attrs)
+        expect_matching_attributes(rating.citation_metadata_raw, json_ld, metadata_attrs)
       end
       # TODO: fallback to description & title to get the topics
       # context "with topics" do
@@ -86,11 +86,11 @@ RSpec.describe MetadataAttributer do
       #   let!(:topic2) { Topic.find_or_create_for_name("Democracy") }
       #   let(:topic_names) { ["Democracy", "Taiwan"] }
       #   it "returns target" do
-      #     json_ld = subject.send(:json_ld_hash, rating.citation_metadata)
+      #     json_ld = subject.send(:json_ld_hash, rating.citation_metadata_raw)
 
       #     expect(subject.send(:keyword_or_text_topic_names, metadata_attrs)).to eq(topic_names)
 
-      #     expect_matching_attributes(rating.citation_metadata, json_ld, metadata_attrs.merge(topic_names: topic_names))
+      #     expect_matching_attributes(rating.citation_metadata_raw, json_ld, metadata_attrs.merge(topic_names: topic_names))
       #   end
       # end
     end
@@ -113,9 +113,9 @@ RSpec.describe MetadataAttributer do
         }
       end
       it "returns target" do
-        json_ld = subject.send(:json_ld_hash, rating.citation_metadata)
+        json_ld = subject.send(:json_ld_hash, rating.citation_metadata_raw)
 
-        expect_matching_attributes(rating.citation_metadata, json_ld, metadata_attrs)
+        expect_matching_attributes(rating.citation_metadata_raw, json_ld, metadata_attrs)
       end
     end
   end


### PR DESCRIPTION
- Make `citation_metadata` a hash (rather than an array)
- Put the citation data into the `raw` key
- Store the attributes from `MetadataAttributer` in an `attrs` key

Running `MetadataAttributer` is becoming a bigger task, so rather than doing it inline, cache the result.

Also, this enables searching for ratings with specific metadata attributes.