### PR TITLE
Add display name to topics

### DIFF
--- a/app/controllers/admin/topic_reviews_controller.rb
+++ b/app/controllers/admin/topic_reviews_controller.rb
@@ -86,7 +86,8 @@ class Admin::TopicReviewsController < Admin::BaseController
   end
 
   def permitted_params
-    params.require(:topic_review).permit(:topic_name, :timezone, :start_at_in_zone, :end_at_in_zone)
+    params.require(:topic_review).permit(:topic_name, :timezone, :display_name,
+      :start_at_in_zone, :end_at_in_zone)
   end
 
   def find_topic_review

--- a/app/controllers/ratings_controller.rb
+++ b/app/controllers/ratings_controller.rb
@@ -182,7 +182,7 @@ class RatingsController < ApplicationController
       @assigning = true
       @assign_topics = Array(topic)
     elsif params[:search_assign_topics].present?
-      topic = Topic.friendly_find(params[:search_assign_topics])
+      topic = Topic.friendly_find(params[:search_assign_topics]) || TopicReview.friendly_find(params[:search_assign_topics])&.topic
       return unless topic.present?
       @assign_topics = [topic]
       @assigning = true

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -10,7 +10,7 @@ class ReviewsController < ApplicationController
 
   def show
     @topic_review_votes = user_topic_review_votes.vote_ordered
-    @action_display_name = @topic_review.topic_name
+    @action_display_name = @topic_review.display_name
     @topic_review_citations = @topic_review.topic_review_citations.vote_ordered
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -185,7 +185,7 @@ module ApplicationHelper
   def topic_review_display(topic_obj, klass = nil)
     topic_obj = topic_obj.first if topic_obj.is_a?(Array) # TODO: fix this
     text = if topic_obj.is_a?(TopicReview)
-      topic_obj&.topic_name
+      topic_obj&.display_name
     elsif topic_obj.is_a?(Topic)
       topic_obj.name
     else

--- a/app/models/topic_review.rb
+++ b/app/models/topic_review.rb
@@ -11,12 +11,12 @@ class TopicReview < ApplicationRecord
 
   enum status: STATUS_ENUM
 
-  validates_presence_of :topic_name
+  validates_presence_of :display_name
 
   before_validation :set_calculated_attributes
   after_commit :update_associations
 
-  scope :name_ordered, -> { order(arel_table["topic_name"].lower) }
+  scope :name_ordered, -> { order(arel_table["display_name"].lower) }
   scope :active_but_ended, -> { active.where("end_at < ?", Time.current) }
   scope :pending_but_started, -> { pending.where("start_at < ?", Time.current) }
   scope :with_end_date, -> { where.not(end_at: nil) }
@@ -58,6 +58,10 @@ class TopicReview < ApplicationRecord
     end_at
   end
 
+  def non_topic_name?
+    topic_name != display_name
+  end
+
   def pending_but_started?
     pending? && start_at < Time.current && end_at > Time.current
   end
@@ -72,11 +76,13 @@ class TopicReview < ApplicationRecord
   end
 
   def set_calculated_attributes
+    self.topic_name = display_name if topic_name.blank?
     if topic_name_changed?
       # Skip update, trigger it manually after commit
       self.topic = Topic.find_or_create_for_name(topic_name, {skip_update_associations: true})
     end
     self.topic_name = topic&.name if topic.present?
+    self.display_name ||= topic_name # Make it work if only topic_name is passed
     self.slug = self.class.slugify(topic_name)
     self.end_at ||= start_at + STANDARD_PERIOD if start_at.present?
     # Reverse the times if they should be reversed

--- a/app/models/topic_review.rb
+++ b/app/models/topic_review.rb
@@ -83,7 +83,7 @@ class TopicReview < ApplicationRecord
     end
     self.topic_name = topic&.name if topic.present?
     self.display_name ||= topic_name # Make it work if only topic_name is passed
-    self.slug = self.class.slugify(topic_name)
+    self.slug = self.class.slugify(display_name)
     self.end_at ||= start_at + STANDARD_PERIOD if start_at.present?
     # Reverse the times if they should be reversed
     if start_at.present? && end_at.present? && end_at < start_at

--- a/app/views/admin/topic_reviews/_form.html.erb
+++ b/app/views/admin/topic_reviews/_form.html.erb
@@ -7,10 +7,17 @@
   <div class="row sm:grid-cols-2">
     <div class="col">
       <div class="form-row">
-        <%= f.label :topic_name, "Topic" %>
-        <%= f.text_field :topic_name, class: "form-control", required: true %>
+        <%= f.label :display_name %>
+        <%= f.text_field :display_name, class: "form-control", required: true %>
       </div>
     </div>
+    <div class="col">
+      <div class="form-row">
+        <%= f.label :topic_name, "Topic" %>
+        <%= f.text_field :topic_name, value: (@topic_review.non_topic_name? ? @topic_review.topic_name : ""), class: "form-control", placeholder: "Leave blank unless different from display name" %>
+      </div>
+    </div>
+
   </div>
   <div class="row sm:grid-cols-2 mb-8">
     <div class="col">

--- a/app/views/admin/topic_reviews/index.html.erb
+++ b/app/views/admin/topic_reviews/index.html.erb
@@ -43,7 +43,7 @@
           </td>
           <td>
             <% if topic_review.non_topic_name? %>
-              <%= topic_review.topic_name %>
+              <small><%= topic_review.topic_name %></small>
             <% end %>
           </td>
           <td>

--- a/app/views/admin/topic_reviews/index.html.erb
+++ b/app/views/admin/topic_reviews/index.html.erb
@@ -13,8 +13,9 @@
           <small><%= sortable "updated_at", skip_sortable: skip_sortable %></small>
         </th>
         <th>
-          <%= sortable "topic_name", skip_sortable: skip_sortable %>
+          <%= sortable "display_name", skip_sortable: skip_sortable %>
         </th>
+        <th class="small">Topic</th>
         <th>
           Status
         </th>
@@ -38,7 +39,12 @@
             <small class="convertTime"><%= l(topic_review.updated_at, format: :convert_time) %></small>
           </td>
           <td>
-            <%= topic_review.topic_name %>
+            <%= topic_review.display_name %>
+          </td>
+          <td>
+            <% if topic_review.non_topic_name? %>
+              <%= topic_review.topic_name %>
+            <% end %>
           </td>
           <td>
             <%= topic_review.status %>

--- a/app/views/landing/index.html.erb
+++ b/app/views/landing/index.html.erb
@@ -19,7 +19,7 @@
 </ol>
 <p class="mb-3">Rating articles is fast&mdash;install the <%= link_to "app / browser extension", browser_extensions_path %> and give it a try.</p>
 
-<h2 class="standard-top-offset mb-4 text-xl">Recent Ratings</h2>
+<h2 class="standard-top-offset mb-1 text-xl">Recent Ratings</h2>
 
 <%= render partial: "/ratings/table", locals: {ratings: @ratings, render_user: true, hide_private_users: true, skip_header: true} %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,9 +52,9 @@
           <%= active_link "Ratings", ratings_landing_url, class: "main-nav-link ml-2" %>
           <% if primary_topic_review.present? %>
             <% rank_active = controller_name == "reviews" && action_name == "show" && @topic_review&.id == primary_topic_review.id %>
-            <%= link_to review_path(primary_topic_review.slug), title: "Review #{primary_topic_review.topic_name}", class: "main-nav-link ml-2 #{rank_active ? 'active' : ''}" do %>
+            <%= link_to review_path(primary_topic_review.slug), title: "Review #{primary_topic_review.display_name}", class: "main-nav-link ml-2 #{rank_active ? 'active' : ''}" do %>
               Review<span class="hidden md:inline">:
-                <strong><%= primary_topic_review.topic_name %></strong>
+                <strong><%= primary_topic_review.display_name %></strong>
               </span>
             <% end %>
           <% end %>

--- a/app/views/ratings/index.html.erb
+++ b/app/views/ratings/index.html.erb
@@ -140,7 +140,7 @@
           <label class="form-control-check"><%# TODO: make this a functioning label_tag %>
             <%= check_box_tag "search_topics[]", topic.slug, checked, class: "submitOnChange" %>
             Only articles about <%= topic_review_display(topic) %>
-            <% if topic.id == primary_topic_id %><small class="less-strong">(current review topic)</small><% end %>
+            <% if topic.id == primary_topic_id %><small class="less-strong">(current topic)</small><% end %>
           </label>
         <% end %>
         <% if primary_topic_review.present? && viewing_current_user? %>

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -31,14 +31,16 @@
 <% elsif @topic_review.pending? %>
   <p>Email <a href="mailto:support@convus.org">support@convus.org</a> if you have questions</p>
 <% else %>
-  <!-- <p class="mb-4">
-    Want help finding articles on <%= @topic_review.topic_name %>? Check out articles other people have
-    <%= link_to "rated on this topic", ratings_path(search_topics: @topic_review.slug) %> to get started.
-  </p> -->
+  <p class="mt-4 mb-4">
+    Check out articles that people have
+    <%= link_to ratings_path(search_topics: @topic_review.topic_name) do %>
+       rated on <strong><%= @topic_review.topic_name %></strong>
+    <% end %>.
+  </p>
 
-  <% if @topic_review_citations.recommended.any? %>
+<!--   <% if @topic_review_citations.recommended.any? %>
     <%= render partial: "/shared/citations_list", locals: {objects: @topic_review_citations.recommended, wrapper_class: "standard-top-offset", title: "Articles which users have recommended on this topic:", show_read: true} %>
-  <% end %>
+  <% end %> -->
 
   <hr class="mt-8">
 
@@ -46,9 +48,9 @@
     <% if current_user.blank? %>
       After you have rated some articles,
     <% elsif @topic_review_votes.blank? %>
-      You haven't marked any ratings applicable to <%= @topic_review.topic_name %> yet.
+      You haven't marked any ratings applicable to <strong><%= @topic_review.topic_name %></strong> yet.
     <% end %>
-    <%= link_to "Select your ratings", ratings_path(user: "current_user", search_assign_topics: @topic_review&.slug) %> that apply to this topic and rank them here.
+    <%= link_to "Select your ratings", ratings_path(user: "current_user", search_assign_topics: @topic_review&.slug) %> that apply to this topic. Rank them here by dragging and dropping them (higher up on the list is better).
   </p>
 <% end %>
 

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -34,11 +34,11 @@
   <p class="mt-4 mb-4">
     Check out articles that people have
     <%= link_to ratings_path(search_topics: @topic_review.topic_name) do %>
-       rated on <strong><%= @topic_review.topic_name %></strong>
+      rated on <strong><%= @topic_review.topic_name %></strong>
     <% end %>.
   </p>
 
-<!--   <% if @topic_review_citations.recommended.any? %>
+  <!--   <% if @topic_review_citations.recommended.any? %>
     <%= render partial: "/shared/citations_list", locals: {objects: @topic_review_citations.recommended, wrapper_class: "standard-top-offset", title: "Articles which users have recommended on this topic:", show_read: true} %>
   <% end %> -->
 

--- a/db/migrate/20230610000241_add_display_name_to_topic_reviews.rb
+++ b/db/migrate/20230610000241_add_display_name_to_topic_reviews.rb
@@ -1,0 +1,5 @@
+class AddDisplayNameToTopicReviews < ActiveRecord::Migration[7.0]
+  def change
+    add_column :topic_reviews, :display_name, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_16_230223) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_10_000241) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -175,6 +175,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_16_230223) do
     t.string "slug"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "display_name"
     t.index ["topic_id"], name: "index_topic_reviews_on_topic_id"
   end
 

--- a/spec/models/topic_review_spec.rb
+++ b/spec/models/topic_review_spec.rb
@@ -97,14 +97,16 @@ RSpec.describe TopicReview, type: :model do
       expect(topic_review.update(updated_at: Time.current)).to be_truthy
       expect(topic_review).to be_valid
       expect(topic_review.topic_name).to eq name
+      expect(topic_review.display_name).to eq name
     end
     context "create with name" do
-      let(:topic_review) { TopicReview.new(topic_name: "Some cool topic") }
+      let(:topic_review) { TopicReview.new(topic_name: "Some cool topic", display_name: "Other name") }
       it "creates a topic with the name if new, otherwise it assigns" do
         expect {
           expect(topic_review.save).to be_truthy
         }.to change(Topic, :count).by 1
         expect(topic_review.topic_name).to eq "Some cool topic"
+        expect(topic_review.display_name).to eq "Other name"
         topic = topic_review.topic
 
         expect {
@@ -125,6 +127,7 @@ RSpec.describe TopicReview, type: :model do
           topic.update(name: "Cool topic")
           expect(topic_review.reload.topic_id).to eq topic.id
           expect(topic_review.topic_name).to eq "Cool topic"
+          expect(topic_review.display_name).to eq "Other name"
         end
       end
     end

--- a/spec/requests/admin/topic_reviews_request_spec.rb
+++ b/spec/requests/admin/topic_reviews_request_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe base_url, type: :request do
       topic_name: "Example topic",
       start_at_in_zone: form_formatted_time(start_at),
       end_at_in_zone: form_formatted_time(end_at),
-      timezone: "America/Bogota"
+      timezone: "America/Bogota",
+      display_name: "Questions about Example Topic"
     }
   end
 
@@ -91,13 +92,25 @@ RSpec.describe base_url, type: :request do
     end
 
     describe "update" do
+      let(:display_name) { "Questions about Example Topic" }
       it "updates" do
         expect(topic_review).to be_valid
         expect(topic_review.status).to eq "pending"
-        patch "#{base_url}/#{topic_review.id}", params: {topic_review: valid_params}
+        topic_id = topic_review.topic_id
+        expect {
+          patch "#{base_url}/#{topic_review.id}", params: {topic_review: valid_params}
+        }.to change(Topic, :count).by 1
         expect(flash[:success]).to be_present
         expect(topic_review.reload.topic_name).to eq "Example topic"
         expect(topic_review.status).to eq "active"
+        expect(topic_review.display_name).to eq display_name
+        expect {
+          patch "#{base_url}/#{topic_review.id}", params: {
+            topic_review: valid_params.merge(topic_name: " ")
+          }
+        }.to change(Topic, :count).by 1
+        expect(topic_review.reload.topic_name).to eq display_name
+        expect(topic_review.display_name).to eq display_name
       end
     end
 

--- a/spec/requests/admin/topic_reviews_request_spec.rb
+++ b/spec/requests/admin/topic_reviews_request_spec.rb
@@ -96,7 +96,6 @@ RSpec.describe base_url, type: :request do
       it "updates" do
         expect(topic_review).to be_valid
         expect(topic_review.status).to eq "pending"
-        topic_id = topic_review.topic_id
         expect {
           patch "#{base_url}/#{topic_review.id}", params: {topic_review: valid_params}
         }.to change(Topic, :count).by 1


### PR DESCRIPTION
Out of (a perhaps misguided) desire to have something like a review topic of:

> When should I buy American

Apply to **Buy American**

This adds `display_name` to topics and uses that. It definitely makes things confusing!