### PR TITLE
Add ability to pass in base url for *_display helpers

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -82,7 +82,7 @@ module ApplicationHelper
         {"search_disagree" => nil, "search_agree" => nil}
       else
         {"search_disagree" => false, "search_agree" => false}
-          .merge("search_#{agreement.to_s}" => true)
+          .merge("search_#{agreement}" => true)
       end
       link_to(display_icon(agreement),
         url_for_sortable_link_merge(link, u_params),

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -74,17 +74,21 @@ module ApplicationHelper
 
   def agreement_display(agreement = nil, link: false)
     return nil if agreement.blank?
-    if agreement.to_s == "neutral"
+    agreement = agreement.to_s
+    if agreement == "neutral"
       nil
     elsif link
-      # TODO: tests :/
-      u_params = {"search_disagree" => false, "search_agree" => false}
-      u_params["search_#{agreement}"] = !(@search_agreement == agreement)
+      u_params = if @search_agreement.to_s == agreement
+        {"search_disagree" => nil, "search_agree" => nil}
+      else
+        {"search_disagree" => false, "search_agree" => false}
+          .merge("search_#{agreement.to_s}" => true)
+      end
       link_to(display_icon(agreement),
-        url_for(sortable_params.merge(u_params)),
+        url_for_sortable_link_merge(link, u_params),
         title: agreement.to_s&.titleize)
     else
-      content_tag(:span, display_icon(agreement), title: agreement.to_s&.titleize)
+      content_tag(:span, display_icon(agreement), title: agreement&.titleize)
     end
   end
 
@@ -93,9 +97,10 @@ module ApplicationHelper
     str = Rating.quality_humanized(quality)
     return nil if str == "medium"
     if link
+      # TODO: tests :/
       link_target = params["search_quality_#{str}"].present? ? nil : true
       link_to(display_icon("quality_#{str}"),
-        url_for(sortable_params.merge("search_quality_#{str}" => link_target)),
+        url_for_sortable_link_merge(link, {"search_quality_#{str}" => link_target}),
         title: "#{str.titleize} Quality")
     else
       content_tag(:span, display_icon("quality_#{str}"), title: "#{str.titleize} Quality")
@@ -105,8 +110,9 @@ module ApplicationHelper
   def learned_something_display(learned_something, link: false)
     return nil unless learned_something
     if link
+      # TODO: tests :/
       link_to(display_icon("learned"),
-        url_for(sortable_params.merge(search_learned_something: !@search_learned_something)),
+        url_for_sortable_link_merge(link, {search_learned_something: !@search_learned_something}),
         title: "Learned something")
     else
       content_tag(:span, display_icon("learned"), title: "Learned something")
@@ -116,8 +122,9 @@ module ApplicationHelper
   def changed_opinion_display(changed_opinion, link: false)
     return nil unless changed_opinion
     if link
+      # TODO: tests :/
       link_to(display_icon("changed"),
-        url_for(sortable_params.merge(search_changed_opinion: !@search_changed_opinion)),
+        url_for_sortable_link_merge(link, {search_changed_opinion: !@search_changed_opinion}),
         title: "Changed opinion")
     else
       content_tag(:span, display_icon("changed"), title: "Changed opinion")
@@ -127,8 +134,9 @@ module ApplicationHelper
   def significant_factual_error_display(significant_factual_error, link: false)
     return nil unless significant_factual_error
     if link
+      # TODO: tests :/
       link_to(display_icon("error"),
-        url_for(sortable_params.merge(search_significant_factual_error: !@search_significant_factual_error)),
+        url_for_sortable_link_merge(link, {search_significant_factual_error: !@search_significant_factual_error}),
         title: "Factual error")
     else
       content_tag(:span, display_icon("error"), title: "Factual error")
@@ -138,8 +146,9 @@ module ApplicationHelper
   def not_understood_display(not_understood, link: false)
     return nil unless not_understood
     if link
+      # TODO: tests :/
       link_to(display_icon("not_understood"),
-        url_for(sortable_params.merge(search_not_understood: !@search_not_understood)),
+        url_for_sortable_link_merge(link, {search_not_understood: !@search_not_understood}),
         title: "Didn't understand")
     else
       content_tag(:span, display_icon("not_understood"), title: "Didn't understand")
@@ -149,8 +158,9 @@ module ApplicationHelper
   def not_finished_display(not_finished, link: false)
     return nil unless not_finished
     if link
+      # TODO: tests :/
       link_to(display_icon("not_finished"),
-        url_for(sortable_params.merge(search_not_finished: !@search_not_finished)),
+        url_for_sortable_link_merge(link, {search_not_finished: !@search_not_finished}),
         title: "Did not finish")
     else
       content_tag(:span, display_icon("not_finished"), title: "Did not finish")
@@ -230,5 +240,16 @@ module ApplicationHelper
     safe_join(name_and_slugs.map { |ns|
       link_to("##{ns[0]}", raw("#{url}&search_topics[]=#{ns[1]}"), html_opts)
     }, " ")
+  end
+
+  private
+
+  def url_for_sortable_link_merge(link, merge_params = {})
+    url_for(sortable_link_merge(link, merge_params))
+  end
+
+  def sortable_link_merge(link, merge_params = {})
+    sortable_url_for_params = link.is_a?(Hash) ? link.merge(sortable_params) : sortable_params
+    sortable_url_for_params.merge(merge_params.with_indifferent_access)
   end
 end

--- a/app/views/admin/ratings/_table.html.erb
+++ b/app/views/admin/ratings/_table.html.erb
@@ -1,6 +1,6 @@
 <% ratings ||= @ratings %>
 <% skip_sortable ||= false %>
-<% filter_links ||= !skip_sortable %>
+<% filter_link ||= !skip_sortable %>
 
 <% table_classes = "table table-sm break-words max-w-full" %>
 <div class="">
@@ -45,12 +45,12 @@
             </small>
             <%= link_to display_icon("link"), rating.citation_url, class: "mr-2" %>
             <span class="">
-              <%= agreement_display(rating.agreement, link: filter_links) %>
-              <%= quality_display(rating.quality, link: filter_links) %>
-              <%= learned_something_display(rating.learned_something?, link: filter_links) %>
-              <%= changed_opinion_display(rating.changed_opinion?, link: filter_links) %>
-              <%= significant_factual_error_display(rating.significant_factual_error?, link: filter_links) %>
-              <%= not_finished_display(rating.not_finished?, link: filter_links) %>
+              <%= agreement_display(rating.agreement, link: filter_link) %>
+              <%= quality_display(rating.quality, link: filter_link) %>
+              <%= learned_something_display(rating.learned_something?, link: filter_link) %>
+              <%= changed_opinion_display(rating.changed_opinion?, link: filter_link) %>
+              <%= significant_factual_error_display(rating.significant_factual_error?, link: filter_link) %>
+              <%= not_finished_display(rating.not_finished?, link: filter_link) %>
             </span>
             <span class="block text-sm less-strong"><%= rating.topic_names.join(", ") %></span>
           </td>

--- a/app/views/landing/index.html.erb
+++ b/app/views/landing/index.html.erb
@@ -19,8 +19,12 @@
 </ol>
 <p class="mb-3">Rating articles is fast&mdash;install the <%= link_to "app / browser extension", browser_extensions_path %> and give it a try.</p>
 
-<h2 class="standard-top-offset mb-1 text-xl">Recent Ratings</h2>
+<h2 class="standard-top-offset mb-1 text-xl">
+  Recent Ratings
+  <%= Rails.application.routes.recognize_path("/ratings") %>
+  <%= link_to "TEST", url_for(request.params.merge({search_agree: true})) %>
+</h2>
 
-<%= render partial: "/ratings/table", locals: {ratings: @ratings, render_user: true, hide_private_users: true, skip_header: true} %>
+<%= render partial: "/ratings/table", locals: {ratings: @ratings, render_user: true, hide_private_users: true, skip_header: true, url_for_route: ratings_path} %>
 
 <h4 class="mt-5"><%= link_to "... view more ratings", ratings_landing_url %></h4>

--- a/app/views/landing/index.html.erb
+++ b/app/views/landing/index.html.erb
@@ -21,8 +21,6 @@
 
 <h2 class="standard-top-offset mb-1 text-xl">
   Recent Ratings
-  <%= Rails.application.routes.recognize_path("/ratings") %>
-  <%= link_to "TEST", url_for(request.params.merge({search_agree: true})) %>
 </h2>
 
 <%= render partial: "/ratings/table", locals: {ratings: @ratings, render_user: true, hide_private_users: true, skip_header: true, url_for_route: ratings_path} %>

--- a/app/views/ratings/_table.html.erb
+++ b/app/views/ratings/_table.html.erb
@@ -14,7 +14,10 @@
 <% ranking_modifier ||= 0 %>
 <% ranking_count = render_ranking && ratings.count  %>
 
-<% filter_links ||= !render_ranking %>
+<% filter_link ||= !render_ranking %>
+<% url_for_route ||= nil # specify a search path, otherwise uses current path %>
+<% url_for_route_params ||= url_for_route.present? ? Rails.application.routes.recognize_path(url_for_route) : {} %>
+<% filter_link = url_for_route_params if filter_link && url_for_route_params.present? %>
 
 <% group_citation_ratings = !render_assign_topic && !render_ranking %>
 
@@ -69,15 +72,15 @@
               <% if rating.missing_url? || rating.citation.blank? %>
                 <%= rating_display(rating) %>
               <% else %>
-                <%= render partial: "/shared/citation", locals: {citation: rating.citation} %>
+                <%= render partial: "/shared/citation", locals: {citation: rating.citation, url_for_route_params: url_for_route_params} %>
               <% end %>
 
-              <%= render partial: "/shared/rating_row", locals: {rating: rating, render_user: render_user, filter_links: filter_links, hide_private_users: hide_private_users, shown_private_user_ids: shown_private_user_ids, wrapper_class: "mt-2"} %>
+              <%= render partial: "/shared/rating_row", locals: {rating: rating, render_user: render_user, filter_link: filter_link, hide_private_users: hide_private_users, shown_private_user_ids: shown_private_user_ids, wrapper_class: "mt-2"} %>
 
               <% if group_citation_ratings %>
                 <% rendered_ids << rating.citation_id %>
                 <% viewable_ratings.where(citation_id: rating.citation_id).where.not(id: rating.id).each do |o_rating| %>
-                  <%= render partial: "/shared/rating_row", locals: {rating: o_rating, render_user: render_user, filter_links: filter_links, hide_private_users: hide_private_users, shown_private_user_ids: shown_private_user_ids} %>
+                  <%= render partial: "/shared/rating_row", locals: {rating: o_rating, render_user: render_user, filter_link: filter_link, hide_private_users: hide_private_users, shown_private_user_ids: shown_private_user_ids} %>
                 <% end %>
               <% end %>
             </td>

--- a/app/views/shared/_citation.html.erb
+++ b/app/views/shared/_citation.html.erb
@@ -1,15 +1,26 @@
+<% url_for_route ||= nil # specify a search path, otherwise uses current path %>
+<% url_for_route_params ||= url_for_route.present? ? Rails.application.routes.recognize_path(url_for_route) : {} %>
+
+<% sortable_url_for_params = url_for_route_params.merge(sortable_params) %>
+
 <h4 class="text-lg leading-5 mb-1" style=""><%= link_to citation.title, citation.url, class: "no-underline hover:underline" %></h4>
 <% if citation.description.present? || citation.topics.present? %>
   <p class="leading-5 mb-1">
     <%= citation.description %>
     <span class="text-sm text-gray-400 mb-1">
-      <%= topic_links(citation.topics, {class: "text-gray-400", include_current: true}) %>
+      <%= topic_links(citation.topics, {class: "text-gray-400", include_current: true}, url: url_for_route) %>
     </span>
   </p>
 <% end %>
 <p class="leading-5 mb-1 text-gray-500 text-sm">
   <% if citation.published_at.present? %>
     <span class="convertTime skipTimeTitle mr-2" title="Published at"><%= l(citation.published_at, format: :convert_time) %></span>
+  <% end %>
+  <%# skip showing publisher if self published %>
+  <% if [citation.publisher_name] != citation.authors_rendered %>
+    <span class="mr-2">
+      <%= link_to citation.publisher_name, sortable_url_for_params.merge(search_publisher: citation.publisher_name), class: "text-gray-500 no-underline" %>
+    </span>
   <% end %>
   <% if citation.authors_rendered.any? %>
     <span class="mr-2">
@@ -18,7 +29,7 @@
       <% citation.authors_rendered.each_with_index do |author, index| %>
         <% collapsed = rendered_text.length > 50 %>
         <span class="<%= collapsed ? 'collapsible hidden' : '' %>">
-          <%= link_to(author, url_for(sortable_params.merge(search_author: author)), class: "text-gray-500 no-underline") %><%= index < authors_count ? ", " : "" %>
+          <%= link_to(author, url_for(sortable_url_for_params.merge(search_author: author)), class: "text-gray-500 no-underline") %><%= index < authors_count ? ", " : "" %>
         </span>
         <% rendered_text += author %>
       <% end %>
@@ -27,9 +38,6 @@
       <% end %>
     </span>
   <% end %>
-  <span class="mr-2">
-    <%= link_to citation.publisher_name, sortable_params.merge(search_publisher: citation.publisher_name), class: "text-gray-500 no-underline" %>
-  </span>
   <% if citation.paywall %>
     <span class="-ml-1 mr-2">($)</span>
   <% end %>

--- a/app/views/shared/_rating_row.html.erb
+++ b/app/views/shared/_rating_row.html.erb
@@ -2,6 +2,10 @@
 <% show_private_user = private_user && shown_private_user_ids.include?(rating.user_id) %>
 
 <% wrapper_class ||= "" %>
+
+<%# NOTE: filter_link can be a boolean OR route hash (e.g. {controller: "ratings", action: "index"}) %>
+<% filter_link ||= false %>
+
 <span class="block <%= wrapper_class %>">
   <small class="">
     Rated <span class="convertTime"><%= l(rating.created_at, format: :convert_time) %></span>

--- a/app/views/shared/_rating_row.html.erb
+++ b/app/views/shared/_rating_row.html.erb
@@ -22,12 +22,12 @@
     <small class="mr-1 less-strong"><%= link_to "edit rating", edit_rating_path(rating) %></small>
   <% end %>
   <span class="">
-    <%= agreement_display(rating.agreement, link: filter_links) %>
-    <%= quality_display(rating.quality, link: filter_links) %>
-    <%= learned_something_display(rating.learned_something?, link: filter_links) %>
-    <%= changed_opinion_display(rating.changed_opinion?, link: filter_links) %>
-    <%= not_understood_display(rating.not_understood?, link: filter_links) %>
-    <%= not_finished_display(rating.not_finished?, link: filter_links) %>
-    <%= significant_factual_error_display(rating.significant_factual_error?, link: filter_links) %>
+    <%= agreement_display(rating.agreement, link: filter_link) %>
+    <%= quality_display(rating.quality, link: filter_link) %>
+    <%= learned_something_display(rating.learned_something?, link: filter_link) %>
+    <%= changed_opinion_display(rating.changed_opinion?, link: filter_link) %>
+    <%= not_understood_display(rating.not_understood?, link: filter_link) %>
+    <%= not_finished_display(rating.not_finished?, link: filter_link) %>
+    <%= significant_factual_error_display(rating.significant_factual_error?, link: filter_link) %>
   </span>
 </span>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -17,6 +17,32 @@ RSpec.describe ApplicationHelper, type: :helper do
       it "returns -" do
         expect(agreement_display(:agree)).to eq target
       end
+      context "link" do
+        let(:target) { "<a title=\"Agree\" href=\"/ratings?search_agree=true&amp;search_disagree=false\"><img class=\"w-4 inline-block\" src=\"/images/icons/agree_icon.svg\" /></a>" }
+        let(:target_no_agreement) { "<a title=\"Agree\" href=\"/ratings\"><img class=\"w-4 inline-block\" src=\"/images/icons/agree_icon.svg\" /></a>" }
+        it "returns with link" do
+          bp = {controller: "ratings", action: "index"}
+          expect(agreement_display("agree", link: bp)).to eq target
+          expect(agreement_display(:agree, link: bp.merge(search_agree: false, search_disagree: true))).to eq target
+          expect(agreement_display("agree", link: bp.merge(search_disagree: false))).to eq target
+          expect(agreement_display(:agree, link: bp.merge(search_disagree: true, search_agree: false))).to eq target
+          # Sam result if search_agreement == disagree
+          @search_agreement = :disagree
+          expect(agreement_display("agree", link: bp)).to eq target
+
+          # link has no search_agreement params:
+          @search_agreement = :agree
+          expect(agreement_display("agree", link: bp)).to eq target_no_agreement
+          expect(agreement_display(:agree, link: bp.merge(search_agree: true))).to eq target_no_agreement
+        end
+        # context "link: true" do
+        #   # TODO: need to stub current route I think? Not sure exactly what to do to make
+        #   # url_for() correctly pull the current controller_name and action_name in tests
+        #   it "returns with link" do
+        #     expect(agreement_display(:agree, link: true)).to eq target
+        #   end
+        # end
+      end
     end
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -25,17 +25,9 @@ RSpec.describe ApplicationHelper, type: :helper do
           expect(agreement_display(:agree, link: bp.merge(search_agree: false, search_disagree: true))).to eq target
           expect(agreement_display("agree", link: bp.merge(search_disagree: false))).to eq target
           expect(agreement_display(:agree, link: bp.merge(search_disagree: true, search_agree: false))).to eq target
-          # Sam result if search_agreement == disagree
+          # Same result if search_agreement == disagree
           @search_agreement = :disagree
           expect(agreement_display("agree", link: bp)).to eq target
-        end
-        context "matching search_agreement" do
-          let(:target) { "<a title=\"Agree\" href=\"/ratings\"><img class=\"w-4 inline-block\" src=\"/images/icons/agree_icon.svg\" /></a>" }
-          before { @search_agreement = :agree }
-          it "returns with link with no agreement params" do
-            expect(agreement_display("agree", link: bp)).to eq target_no_agreement
-            expect(agreement_display(:agree, link: bp.merge(search_agree: true))).to eq target_no_agreement
-          end
         end
         # context "link: true" do
         #   # TODO: need to stub current route I think? Not sure exactly what to do to make
@@ -44,6 +36,14 @@ RSpec.describe ApplicationHelper, type: :helper do
         #     expect(agreement_display(:agree, link: true)).to eq target
         #   end
         # end
+        context "matching search_agreement" do
+          let(:target) { "<a title=\"Agree\" href=\"/ratings\"><img class=\"w-4 inline-block\" src=\"/images/icons/agree_icon.svg\" /></a>" }
+          before { @search_agreement = :agree }
+          it "returns with link with no agreement params" do
+            expect(agreement_display("agree", link: bp)).to eq target_no_agreement
+            expect(agreement_display(:agree, link: bp.merge(search_agree: true))).to eq target_no_agreement
+          end
+        end
       end
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe ApplicationHelper, type: :helper do
           let(:target) { "<a title=\"Agree\" href=\"/ratings\"><img class=\"w-4 inline-block\" src=\"/images/icons/agree_icon.svg\" /></a>" }
           before { @search_agreement = :agree }
           it "returns with link with no agreement params" do
-            expect(agreement_display("agree", link: bp)).to eq target_no_agreement
-            expect(agreement_display(:agree, link: bp.merge(search_agree: true))).to eq target_no_agreement
+            expect(agreement_display("agree", link: bp)).to eq target
+            expect(agreement_display(:agree, link: bp.merge(search_agree: true))).to eq target
           end
         end
       end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -19,9 +19,8 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
       context "link" do
         let(:target) { "<a title=\"Agree\" href=\"/ratings?search_agree=true&amp;search_disagree=false\"><img class=\"w-4 inline-block\" src=\"/images/icons/agree_icon.svg\" /></a>" }
-        let(:target_no_agreement) { "<a title=\"Agree\" href=\"/ratings\"><img class=\"w-4 inline-block\" src=\"/images/icons/agree_icon.svg\" /></a>" }
+        let(:bp) { {controller: "ratings", action: "index"} }
         it "returns with link" do
-          bp = {controller: "ratings", action: "index"}
           expect(agreement_display("agree", link: bp)).to eq target
           expect(agreement_display(:agree, link: bp.merge(search_agree: false, search_disagree: true))).to eq target
           expect(agreement_display("agree", link: bp.merge(search_disagree: false))).to eq target
@@ -29,11 +28,14 @@ RSpec.describe ApplicationHelper, type: :helper do
           # Sam result if search_agreement == disagree
           @search_agreement = :disagree
           expect(agreement_display("agree", link: bp)).to eq target
-
-          # link has no search_agreement params:
-          @search_agreement = :agree
-          expect(agreement_display("agree", link: bp)).to eq target_no_agreement
-          expect(agreement_display(:agree, link: bp.merge(search_agree: true))).to eq target_no_agreement
+        end
+        context "matching search_agreement" do
+          let(:target) { "<a title=\"Agree\" href=\"/ratings\"><img class=\"w-4 inline-block\" src=\"/images/icons/agree_icon.svg\" /></a>" }
+          before { @search_agreement = :agree }
+          it "returns with link with no agreement params" do
+            expect(agreement_display("agree", link: bp)).to eq target_no_agreement
+            expect(agreement_display(:agree, link: bp.merge(search_agree: true))).to eq target_no_agreement
+          end
         end
         # context "link: true" do
         #   # TODO: need to stub current route I think? Not sure exactly what to do to make


### PR DESCRIPTION
e.g. make it so clicking on "High quality" on a rating on the landing page needs to send you to the ratings index search for high quality

(Previous behavior was reloading the landing page with `?search_quality_high=true` - which doesn't do anything)