### PR TITLE
Revise publisher name generation

### DIFF
--- a/app/models/citation.rb
+++ b/app/models/citation.rb
@@ -163,6 +163,10 @@ class Citation < ApplicationRecord
     published_updated_at
   end
 
+  def published_updated_at_with_fallback
+    published_updated_at || published_at || created_at || Time.current
+  end
+
   def publisher_name
     publisher&.name
   end
@@ -238,7 +242,7 @@ class Citation < ApplicationRecord
     end
     current_m_attrs << "citation_text" if manually_updating && citation_text_changed?
     self.manually_updated_attributes = current_m_attrs.uniq.sort
-    self.manually_updated_at = manually_updated_attributes.any? ? Time.now : nil
+    self.manually_updated_at = manually_updated_attributes.any? ? Time.current : nil
   end
 
   # Called if publisher updated with remove_query, in callback - so do a direct update

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -26,12 +26,8 @@ class Publisher < ApplicationRecord
       create(domain: domain, name: name, remove_query: remove_query)
   end
 
-  def domain_to_name
-    domain&.gsub(/\.[^.]*\z/, "")
-  end
-
   def name_assigned?
-    name != domain_to_name
+    name&.downcase != domain&.downcase
   end
 
   def keep_query?
@@ -44,8 +40,8 @@ class Publisher < ApplicationRecord
 
   def set_calculated_attributes
     @remove_query_enabled = remove_query_changed? && remove_query
+    self.name ||= domain
     self.domain = domain&.downcase
-    self.name ||= domain_to_name
     self.slug = self.class.slugify(name)
     self.base_word_count ||= BASE_WORD_COUNT
   end

--- a/spec/jobs/update_citation_metadata_from_ratings_job_spec.rb
+++ b/spec/jobs/update_citation_metadata_from_ratings_job_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe UpdateCitationMetadataFromRatingsJob, type: :job do
       end
       it "parses" do
         expect(citation.url).to eq submitted_url.gsub("?utm_s=example", "")
-        expect(publisher.reload.name).to eq "newyorker"
+        expect(publisher.reload.name).to eq "newyorker.com"
         expect(publisher.name_assigned?).to be_falsey
         expect(publisher.base_word_count).to eq 100
         expect(rating.metadata_at).to be_within(1).of Time.current

--- a/spec/models/citation_spec.rb
+++ b/spec/models/citation_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe Citation, type: :model do
         expect(citation.reload.topics.pluck(:id)).to eq([topic.id])
         expect(citation.topics_string).to eq "San Francisco"
         expect(citation.manually_updated_attributes).to eq(["topics"])
-        expect(citation.manually_updated_at).to be_within(1).of Time.now
+        expect(citation.manually_updated_at).to be_within(1).of Time.current
         citation.manually_updating = false
         citation.update(topics_string: " ")
         expect(citation.reload.topics_string).to be_blank
@@ -250,6 +250,29 @@ RSpec.describe Citation, type: :model do
       it "returns target" do
         expect(citation.references_filepath).to eq target
         expect(Citation.references_filepath(url)).to eq target
+      end
+    end
+  end
+
+  describe "published_updated_at_with_fallback" do
+    let(:time) { Time.current }
+    let(:citation) { Citation.new(created_at: time) }
+    it "is created_at for citations without published_at" do
+      expect(citation.published_updated_at).to be_blank
+      expect(citation.published_at).to be_blank
+      expect(citation.published_updated_at_with_fallback).to be_within(1).of(time)
+      expect(Citation.new.published_updated_at_with_fallback).to be_within(1).of(Time.current)
+    end
+    context "published_at" do
+      let(:citation) { Citation.new(published_at: time, created_at: Time.current) }
+      it "is published_at" do
+        expect(citation.published_updated_at_with_fallback).to be_within(1).of(time)
+      end
+    end
+    context "published_updated_at" do
+      let(:citation) { Citation.new(published_updated_at: time, published_at: Time.current, created_at: Time.current) }
+      it "is published_updated_at" do
+        expect(citation.published_updated_at_with_fallback).to be_within(1).of(time)
       end
     end
   end

--- a/spec/requests/admin/publishers_request_spec.rb
+++ b/spec/requests/admin/publishers_request_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe base_url, type: :request do
     describe "update" do
       let(:valid_params) { {name: "99 Percent Invisible", remove_query: true, base_word_count: "30"} }
       it "updates" do
-        expect(publisher.reload.name).to eq "99percentinvisible"
+        expect(publisher.reload.name).to eq "99percentinvisible.org"
         expect(publisher.remove_query).to be_falsey
         expect(publisher.base_word_count).to eq 100
         patch "#{base_url}/#{publisher.id}", params: {publisher: valid_params}


### PR DESCRIPTION
Use the full domain by default (`wsj.com`) instead of the domain without the TLD (`wsj`)

Also, add `published_updated_at_with_fallback` to Citation

(both of these are being used by #74, but make sense to ship separately)