### PR TITLE
Remove leftover static_dev reference from bin/lint

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -15,7 +15,7 @@ def system!(*args)
 end
 
 def html_files
-  (Dir.glob("app/**/*.{html}{+*,}.erb") + Dir.glob(".static_dev/*.html"))
+  Dir.glob("app/**/*.{html}{+*,}.erb")
     .map { |f| "'#{f}'" }.join(" ")
 end
 


### PR DESCRIPTION
- The `.static_dev` directory was removed in #121, but a glob reference in `bin/lint` was left behind
- Removes the `.static_dev/*.html` glob from the `html_files` method in the lint script
