### PR TITLE
Handle JSON-LD @type arrays with multiple types

### DIFF
--- a/app/services/metadata_json_ld_parser.rb
+++ b/app/services/metadata_json_ld_parser.rb
@@ -70,7 +70,13 @@ class MetadataJsonLdParser
 
     def type_values(values)
       values = val_or_first_item(values)
-      [val_or_first_item(values["@type"]), values]
+      [type_key(values["@type"]), values]
+    end
+
+    # @type is sometimes an array of types (e.g. ["Person", "Organization"])
+    def type_key(type)
+      return type unless type.is_a?(Array)
+      ((KEY_PRIORITY + PUBLISHER_KEY_PRIORITY) & type).first || type.first
     end
 
     # IDK why they wrap some values in arrays! Just deal with it

--- a/spec/services/metadata_json_ld_parser_spec.rb
+++ b/spec/services/metadata_json_ld_parser_spec.rb
@@ -150,6 +150,21 @@ RSpec.describe MetadataJsonLdParser do
         end
       end
     end
+    context "array of @types" do
+      let(:values) do
+        [
+          {"url" => "https://www.example.com", "@type" => ["WebSite"]},
+          {"name" => "Jane Doe", "@type" => ["Person", "Organization"]},
+          {"name" => "John Doe", "@type" => ["Person", "Unknownthing"]}
+        ]
+      end
+      let(:target) { %w[WebSite Organization Person].zip(values).to_h }
+      it "uses the prioritized type" do
+        expect(subject.content_hash(rating_metadata)).to eq target
+
+        expect(subject.parse(rating_metadata)).to eq(values.first.merge("@type" => "WebSite", "publisher" => "Jane Doe"))
+      end
+    end
     context "more dataexample" do
       let(:values) { [{"url" => "https://example.com", "@type" => "NewsArticle", "image" => {"url" => "https://example.com/image.png", "@type" => "ImageObject", "width" => 2057, "height" => 1200}, "author" => ["John Doe"], "creator" => ["John Doe"], "hasPart" => [], "@context" => "http://schema.org", "headline" => "example title", "keywords" => ["topic: Cool Matters"]}, {"@type" => "BreadcrumbList", "@context" => "https://schema.org/"}] }
       let(:target) do


### PR DESCRIPTION
Fixes a Honeybadger fault where `UpdateCitationMetadataFromRatingsJob` aborted on `RuntimeError: Array with multiple values: ["Person", "Organization"]` ([fault 133052862](https://app.honeybadger.io/projects/106056/faults/133052862)).

- JSON-LD lets a node declare multiple types — an author who is also the publishing org is `"@type": ["Person", "Organization"]`. `MetadataJsonLdParser` routed `@type` through `val_or_first_item`, which raises on any array with more than one element.
- `@type` now goes through a `type_key` that picks the type this parser cares about (`KEY_PRIORITY` then `PUBLISHER_KEY_PRIORITY`, falling back to the first listed), so the example above keys as `Organization` and becomes eligible for `publisher_name`.
- `val_or_first_item`'s raise is left alone — it still guards the case it was meant for, an array of full JSON-LD objects where picking one silently drops data.
